### PR TITLE
Refactor the Python MCP client to use a JSON configuration file for s…

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,35 @@
+{
+  "mcpServers": {
+    "stock-mcp": {
+         "type": "stdio",
+          "command": "/Users/amitamit/Documents/Code/stock_mcp/.venv/bin/python",
+          "args": [ "/Users/amitamit/Documents/Code/stock_mcp/run_mcp_server.py" ],
+          "env": {
+            "PYTHONPATH": "/Users/amitamit/Documents/Code/stock_mcp",
+            "PYTHONBUFFERED": "1",
+            "ALPHAVANTAGE_API_KEY": "YSCQXNO4EHCKX52A"
+          }
+    },
+    "supabase": {
+          "command": "npx",
+          "args": [
+            "-y",
+            "@supabase/mcp-server-supabase@latest",
+            "--read-only",
+            "--project-ref=vfoyusdsmpnnqrsayeqb"
+          ],
+          "env": {
+            "SUPABASE_ACCESS_TOKEN": "sbp_e02b814d34962141056ed80266769fb0aa227360"
+          }
+        },
+    "pinecone": {
+      "command": "npx",
+      "args": [
+        "-y", "@pinecone-database/mcp"
+      ],
+      "env": {
+        "PINECONE_API_KEY": "pcsk_4GnA1F_AYQcnKhLRqzbcpa3T6E17eq35YKW54YjVtPes1Eh1xxaNEeEdeYgrRqowuWdgJv"
+      }
+    }
+  }
+}


### PR DESCRIPTION
…erver definitions, replacing the previous file-path-based approach.

The client now accepts two new command-line arguments:
- `--config`: Specifies the path to the JSON configuration file.
- `--server`: Specifies the name of the server to connect to from the configuration file.

The client launches the specified server using the command, arguments, and environment variables defined in the JSON file, communicating with it over a stdio interface.